### PR TITLE
Allow for 15 minute timout on magerun executions

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -847,6 +847,7 @@ def magerun(command, description)
     user node['n98-magerun']['user']
     group node['n98-magerun']['group']
     command "#{node['n98-magerun']['install_dir']}/#{node['n98-magerun']['install_file']} -n --root-dir=#{new_resource.path} #{command}"
+    timeout 900
     action :run
   end
   new_resource.updated_by_last_action(true)

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -847,7 +847,7 @@ def magerun(command, description)
     user node['n98-magerun']['user']
     group node['n98-magerun']['group']
     command "#{node['n98-magerun']['install_dir']}/#{node['n98-magerun']['install_file']} -n --root-dir=#{new_resource.path} #{command}"
-    timeout 900
+    timeout 9000
     action :run
   end
   new_resource.updated_by_last_action(true)


### PR DESCRIPTION
When installing with `installSampleData` set to `yes`, the `execute` provider times out depending on connection speed and sample data size (it's a rather large file). Default timeout for the `execute` provider is 3600 seconds. Timeout was bumped up to 9000 seconds.